### PR TITLE
Parametrize fillMode for .useColumns

### DIFF
--- a/client/homebrew/phbStyle/phb.style.less
+++ b/client/homebrew/phbStyle/phb.style.less
@@ -26,9 +26,9 @@ body {
 		letter-spacing : -0.02em;
 	}
 }
-.useColumns(@multiplier : 1){
+.useColumns(@multiplier : 1, @fillMode: auto){
 	column-count         : 2;
-	column-fill          : auto;
+	column-fill          : @fillMode;
 	column-gap           : 1cm;
 	column-width         : 8cm * @multiplier;
 	-webkit-column-count : 2;
@@ -272,7 +272,7 @@ body {
 	}
 	//Full Width
 	hr+hr+blockquote{
-		.useColumns(0.96);
+		.useColumns(0.96, @fillMode: balance);
 	}
 	//*****************************
 	// *           FOOTER


### PR DESCRIPTION
A @fillMode parameter for .useColumns9) allows setting 
`column-fill` property to `balance` for wide statblocks (or other
wide column types) instead of relying on Chrome's fallback
behavior that ignores `auto` when there's no set container height.
Set the default for the for `@fillMode` to `auto` to maintain the
current behavior.